### PR TITLE
Add HTML UI with blue Add Todo button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,15 +170,21 @@ async fn index_html() -> HttpResponse {
     <ul class="todo-list" id="todo-list"></ul>
 
     <script>
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
         async function loadTodos() {
             const res = await fetch('/todos');
             const todos = await res.json();
             const list = document.getElementById('todo-list');
             list.innerHTML = todos.map(todo => `
-                <li class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
-                    <input type="checkbox" ${todo.completed ? 'checked' : ''} onchange="toggleTodo('${todo.id}', this.checked)">
-                    <span>${todo.title}</span>
-                    <button class="delete-btn" onclick="deleteTodo('${todo.id}')">Delete</button>
+                <li class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${escapeHtml(todo.id)}">
+                    <input type="checkbox" ${todo.completed ? 'checked' : ''} onchange="toggleTodo('${escapeHtml(todo.id)}', this.checked)">
+                    <span>${escapeHtml(todo.title)}</span>
+                    <button class="delete-btn" onclick="deleteTodo('${escapeHtml(todo.id)}')">Delete</button>
                 </li>
             `).join('');
         }
@@ -211,7 +217,7 @@ async fn index_html() -> HttpResponse {
         }
 
         document.getElementById('add-todo-btn').addEventListener('click', addTodo);
-        document.getElementById('todo-input').addEventListener('keypress', (e) => {
+        document.getElementById('todo-input').addEventListener('keydown', (e) => {
             if (e.key === 'Enter') addTodo();
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,143 @@ async fn health() -> HttpResponse {
     HttpResponse::Ok().json(serde_json::json!({"status": "ok"}))
 }
 
+async fn index_html() -> HttpResponse {
+    let html = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo App</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 600px;
+            margin: 50px auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; }
+        .add-form {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .add-form input {
+            flex: 1;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+        }
+        .add-form button {
+            background-color: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+        }
+        .add-form button:hover {
+            background-color: #0056b3;
+        }
+        .todo-list {
+            list-style: none;
+            padding: 0;
+        }
+        .todo-item {
+            background: white;
+            padding: 15px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .todo-item.completed span {
+            text-decoration: line-through;
+            color: #888;
+        }
+        .todo-item input[type="checkbox"] {
+            width: 20px;
+            height: 20px;
+        }
+        .todo-item span { flex: 1; }
+        .delete-btn {
+            background: #dc3545;
+            color: white;
+            border: none;
+            padding: 5px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <h1>Todo App</h1>
+    <div class="add-form">
+        <input type="text" id="todo-input" placeholder="Enter a new todo...">
+        <button id="add-todo-btn">Add Todo</button>
+    </div>
+    <ul class="todo-list" id="todo-list"></ul>
+
+    <script>
+        async function loadTodos() {
+            const res = await fetch('/todos');
+            const todos = await res.json();
+            const list = document.getElementById('todo-list');
+            list.innerHTML = todos.map(todo => `
+                <li class="todo-item ${todo.completed ? 'completed' : ''}" data-id="${todo.id}">
+                    <input type="checkbox" ${todo.completed ? 'checked' : ''} onchange="toggleTodo('${todo.id}', this.checked)">
+                    <span>${todo.title}</span>
+                    <button class="delete-btn" onclick="deleteTodo('${todo.id}')">Delete</button>
+                </li>
+            `).join('');
+        }
+
+        async function addTodo() {
+            const input = document.getElementById('todo-input');
+            const title = input.value.trim();
+            if (!title) return;
+            await fetch('/todos', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title })
+            });
+            input.value = '';
+            loadTodos();
+        }
+
+        async function toggleTodo(id, completed) {
+            await fetch(`/todos/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ completed })
+            });
+            loadTodos();
+        }
+
+        async function deleteTodo(id) {
+            await fetch(`/todos/${id}`, { method: 'DELETE' });
+            loadTodos();
+        }
+
+        document.getElementById('add-todo-btn').addEventListener('click', addTodo);
+        document.getElementById('todo-input').addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') addTodo();
+        });
+
+        loadTodos();
+    </script>
+</body>
+</html>"#;
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(html)
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let data = web::Data::new(AppState {
@@ -98,6 +235,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(data.clone())
+            .route("/", web::get().to(index_html))
             .route("/health", web::get().to(health))
             .route("/todos", web::get().to(list_todos))
             .route("/todos", web::post().to(create_todo))


### PR DESCRIPTION
## Summary

- Adds `GET /` endpoint serving an HTML UI for managing todos
- Styles the "Add Todo" button blue (`#007bff`) per HJG-12
- UI includes complete CRUD functionality: add, toggle complete, delete todos

## Test plan

- [ ] Start server with `cargo run`
- [ ] Visit `http://127.0.0.1:8080/`
- [ ] Verify the "Add Todo" button is blue
- [ ] Add a todo and verify it appears in the list
- [ ] Toggle and delete todos to verify full functionality

Closes HJG-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)